### PR TITLE
Remove Settlement From business central

### DIFF
--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -67,7 +67,6 @@ class Expense(BaseForeignWorkspaceModel):
     currency = StringNotNullField(max_length=5, help_text='Home Currency')
     foreign_amount = FloatNullField(help_text='Foreign Amount')
     foreign_currency = StringNullField(max_length=5, help_text='Foreign Currency')
-    settlement_id = StringNullField(help_text='Settlement ID')
     reimbursable = BooleanFalseField(help_text='Expense reimbursable or not')
     state = StringNotNullField(help_text='Expense state')
     vendor = StringNullField(help_text='Vendor')
@@ -129,7 +128,6 @@ class Expense(BaseForeignWorkspaceModel):
                     'foreign_currency': expense['foreign_currency'],
                     'tax_amount': expense['tax_amount'],
                     'tax_group_id': expense['tax_group_id'],
-                    'settlement_id': expense['settlement_id'],
                     'reimbursable': expense['reimbursable'],
                     'billable': expense['billable'] if expense['billable'] else False,
                     'state': expense['state'],

--- a/apps/fyle/serializers.py
+++ b/apps/fyle/serializers.py
@@ -146,4 +146,4 @@ class ExpenseSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Expense
-        fields = ['updated_at', 'claim_number', 'employee_email', 'employee_name', 'fund_source', 'expense_number', 'payment_number', 'vendor', 'category', 'amount', 'report_id', 'settlement_id', 'expense_id']
+        fields = ['updated_at', 'claim_number', 'employee_email', 'employee_name', 'fund_source', 'expense_number', 'payment_number', 'vendor', 'category', 'amount', 'report_id', 'expense_id']

--- a/tests/test_business_central/fixtures.py
+++ b/tests/test_business_central/fixtures.py
@@ -100,7 +100,6 @@ data = {
             'foreign_currency':None,
             'tax_amount':None,
             'tax_group_id':None,
-            'settlement_id':'setDiksMn83K7',
             'reimbursable':True,
             'billable':False,
             'exported':False,

--- a/tests/test_fyle/fixtures.py
+++ b/tests/test_fyle/fixtures.py
@@ -331,7 +331,6 @@ fixtures = {
             'foreign_currency':None,
             'tax_amount':None,
             'tax_group_id':None,
-            'settlement_id':'setDiksMn83K7',
             'reimbursable':True,
             'billable':False,
             'exported':False,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `settlement_id` field from the `Expense` class and `ExpenseSerializer` for streamlined data management.

- **Tests**
  - Updated test fixtures to align with the removal of the `settlement_id` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->