### PR TITLE
fix: change the `report_title` option to `report_name`

### DIFF
--- a/apps/fyle/constants.py
+++ b/apps/fyle/constants.py
@@ -10,7 +10,7 @@ DEFAULT_FYLE_CONDITIONS = [
         'is_custom': False
     },
     {
-        'field_name': 'report_title',
+        'field_name': 'report_name',
         'type': 'TEXT',
         'is_custom': False
     },


### PR DESCRIPTION
## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the field name from 'report_title' to 'report_name' in the default conditions, improving clarity for users.
  
- **Bug Fixes**
	- Corrected terminology to enhance consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->