### PR TITLE
fix: bump fyle accounting mappings  version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ ms-dynamics-business-central-sdk==1.5.2
 
 # Reusable Fyle Packages
 fyle-rest-auth==1.7.2
-fyle-accounting-mappings==1.34.8
+fyle-accounting-mappings==1.34.9
 fyle-integrations-platform-connector==1.39.3
 
 # Postgres Dependincies


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `fyle-accounting-mappings` package from `1.34.8` to `1.34.9`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->