### PR TITLE
fix: delete `expense_attributes_deletion_cache` in workspace reset

### DIFF
--- a/scripts/sql/reset_db.sql
+++ b/scripts/sql/reset_db.sql
@@ -190,6 +190,12 @@ BEGIN
   RAISE NOTICE 'Deleted % users', rcount;
 
   DELETE
+  FROM expense_attributes_deletion_cache
+  WHERE workspace_id = _workspace_id;
+  GET DIAGNOSTICS rcount = ROW_COUNT;
+  RAISE NOTICE 'Deleted % expense_attributes_deletion_cache', rcount;
+
+  DELETE
   FROM workspaces w
   WHERE w.id = _workspace_id;
   GET DIAGNOSTICS rcount = ROW_COUNT;


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the workspace deletion process by adding a new operation to remove associated expense attributes.

These changes improve data integrity during workspace deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->